### PR TITLE
Fix BUILD_DEPENDS handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
         [ -z "${BUILD_PATH}" ] || cd "${BUILD_PATH}"
         case "${{ inputs.install_build_depends }}" in
         yes|true)
-          BUILD_DEPENDS="$(grep -Po '(?<=Build-Depends:).*' debian/control | egrep -o '[a-zA-Z+-]+')"
+          BUILD_DEPENDS="$(grep -Po '(?<=Build-Depends:).*' debian/control | egrep -o '[a-zA-Z][a-zA-Z0-9+-]+' | tr '\n' ' ')"
         ;;
         esac
         BUILD_DEPENDS="${BUILD_DEPENDS} ${{ inputs.additional_build_depends }}"
@@ -92,7 +92,7 @@ runs:
         yes|true)
           dpkg-checkbuilddeps 2>&1 \
           | sed -E 's| \([^)]+\)||g' \
-          | grep -Po 'dependencies: \K.*' \
+          | ( grep -Po 'dependencies: \K.*' || true ) \
           | xargs -r sudo apt-get install -y
         ;;
         esac


### PR DESCRIPTION
- Fix regex to allow package names with numbers, like libuv1-dev or libasound2-dev

- Don't fail if dpkg-checkbuilddeps pipeline fails (for some reason, this pipeline fails when dpkg-checkbuilddeps returns nothing, and it causes failure of the whole action; I wasn't able to reproduce it locally, but the applied workaround works both locally and on CI)